### PR TITLE
adding retry to _whois_validator

### DIFF
--- a/cyrebro_domain_validator/domain_validator.py
+++ b/cyrebro_domain_validator/domain_validator.py
@@ -9,6 +9,7 @@ from tld import get_tld, is_tld
 
 from requests.exceptions import ConnectionError
 from socket import gaierror
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 
 class DomainValidator:
@@ -105,6 +106,7 @@ class DomainValidator:
         except gaierror:
             pass
 
+    @retry(stop=stop_after_attempt(3), wait=wait_fixed(20))
     def _whois_validator(self) -> None:
         """
         To easily validate if the domain has a valid WHOIS data, we use query IANA's WHOIS service to look for

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     url="https://github.com/CYREBRO/cyrebro-domain-validator",
     license="MIT",
     packages=find_packages(),
-    install_requires=["requests", "dnspython>=2.2.1", "tld>=0.12.6"],
+    install_requires=["requests", "dnspython>=2.2.1", "tld>=0.12.6", "tenacity"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
when this package is used in swimlane (for example PIS - Determine Indicator Type) sometimes there are connection timeouts when requesting iana.org, so I added a simple retry mechanism